### PR TITLE
Move compile definition to target library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(SOURCE_DIR                "src/")
 set(INCLUDE_DIR               "include/")
 
 set(CMAKE_CXX_STANDARD 11)
-add_definitions(-D${PROJECT_NAME}uselib)
 
 set(LIB_PATH                                   "${CMAKE_CURRENT_SOURCE_DIR}/build/lib")
 set(BIN_PATH                                   "${CMAKE_CURRENT_SOURCE_DIR}/build/bin")
@@ -29,6 +28,7 @@ add_library(${PROJECT_NAME}
     "${SOURCE_DIR}/EasyFlags.cpp"
 )
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC -D${PROJECT_NAME}uselib)
 target_link_libraries(${PROJECT_NAME} autojson)
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIR})
 


### PR DESCRIPTION
This way, when the project is used as a submodule, the parent project's CMakeLists, after the "include_subdirectory", can simply link the easyflags target lib to any of its targets, without manually setting the compile definition again.